### PR TITLE
Fix notInterruptible flag for UnitCastingInfo and UnitChannelInfo in TBCC

### DIFF
--- a/LibTargetedCasts.lua
+++ b/LibTargetedCasts.lua
@@ -34,14 +34,14 @@ local UnitChannelInfo = UnitChannelInfo
 local isBCC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
 if isBCC then
     UnitCastingInfo = function(...)
-        local name, text, texture, startTimeMS, endTimeMS, isTradeSkill, castID, spellID = _G.UnitCastingInfo(...)
-        local notInterruptible = false
+        local name, text, texture, startTimeMS, endTimeMS, isTradeSkill, castID, notInterruptible, spellID = _G.UnitCastingInfo(...)
+        notInterruptible = false  -- always nil in TBCC
         return name, text, texture, startTimeMS, endTimeMS, isTradeSkill, castID, notInterruptible, spellID
     end
 
     UnitChannelInfo = function(...)
-        local name, text, texture, startTimeMS, endTimeMS, isTradeSkill, spellID = _G.UnitChannelInfo(...)
-        local notInterruptible = false
+        local name, text, texture, startTimeMS, endTimeMS, isTradeSkill, notInterruptible, spellID = _G.UnitChannelInfo(...)
+        notInterruptible = false  -- always nil in TBCC
         return name, text, texture, startTimeMS, endTimeMS, isTradeSkill, notInterruptible, spellID
     end
 end


### PR DESCRIPTION
`UnitCastingInfo` seems to be returning the same number of arguments as on retail, albeit still with `notInterruptible = nil`. I have not tested `UnitChannelInfo`, but I assume they changed it in a similar way.